### PR TITLE
Release 5.1.0 — Flutter 3.44 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simple_html_css
 description: This package allows you to use simple HTML and inline CSS styles to style your text in flutter. A fork of css_text package.
-version: 5.0.0
+version: 5.1.0
 publish_to: https://unpub.plentific.com/
 repository: https://github.com/plentific/simple_html_css_flutter
 
@@ -11,10 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  xml: ^6.5.0
+  xml: ^7.0.1
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
## JIra Ticket

https://plentific.atlassian.net/browse/INSAPP-2174

## Summary
- Releases **5.1.0** with dependency updates for the Flutter 3.44 upgrade (`xml` ^7.0.1, `flutter_lints` ^6.0.0).
- Includes the **5.0.0** breaking changes: Flutter >= 3.22, removal of built-in HTML unescaping, deprecated API fixes, and refreshed example app scaffolding.

## Test plan
- [ ] `flutter pub get` in package root
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] Run `example/` on iOS or Android simulator
- [ ] Publish to unpub after merge (OOSSA)


Made with [Cursor](https://cursor.com)