### PR TITLE
Update changelog for v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0
+* Update dependencies for Flutter 3.44 compatibility
+* Update `xml` to ^7.0.1
+* Update `flutter_lints` to ^6.0.0
+
 ## 5.0.0
 * **Breaking change** this package now needs a Flutter version >= 3.22
 * Remove html_unescape from package, input has to be unescaped before you pass in


### PR DESCRIPTION
## Description

This PR adds a 5.1.0 section to CHANGELOG.md to match the current version in pubspec.yaml:

- Flutter 3.44 dependency alignment
- xml bumped to ^7.0.1
- flutter_lints bumped to ^6.0.0

This PR aims to resolve a warning when trying to publish the package. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog update with no code or dependency file changes in the diff.
> 
> **Overview**
> Adds a **5.1.0** section at the top of `CHANGELOG.md` so release notes match `version: 5.1.0` in `pubspec.yaml`.
> 
> The new bullets document dependency alignment for Flutter 3.44, `xml` ^7.0.1, and `flutter_lints` ^6.0.0—no runtime or API changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b21012eacd85fc9f8718ce144ce523b23498f96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->